### PR TITLE
fix: embedded HTML causes XML rendering failure

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,6 +22,29 @@ const onRenderError = (error: unknown): never => {
   )
 }
 
+/**
+ * Ensure that the SVG is rendered as valid XML; otherwise embedded items like
+ * `<br>` will cause failures when the Canvas renders.
+ */
+const svgAsXml = (svg: string): string => {
+  const container = document.createElement('div')
+  document.body.appendChild(container) // Append the container to the document body
+  try {
+    container.innerHTML = svg
+    const svgElement = container.firstChild
+    if (svgElement === null) {
+      throw new Error('Expected an SVG element')
+    }
+
+    const xmlSerializer = new XMLSerializer()
+    const xml = xmlSerializer.serializeToString(svgElement)
+
+    return xml
+  } finally {
+    document.body.removeChild(container)
+  }
+}
+
 const main = async () => {
   console.log('logseq-mermaid-plugin loaded')
   const host = logseq.Experiments.ensureHostScope()
@@ -70,6 +93,7 @@ const main = async () => {
           'mermaid-diagram',
           mermaidString,
         )
+        const xml = svgAsXml(svg)
 
         setTimeout(async () => {
           // Passing through the error handler allows better messaging to the

--- a/src/services/get-img-from-svg.ts
+++ b/src/services/get-img-from-svg.ts
@@ -4,6 +4,7 @@ export const getImgFromSvg = (
   svg: string,
   mermaidId: string,
   scale: number,
+  onError: (error: unknown) => void,
 ) => {
   const canvas = document.createElement('canvas')
   const ctx = canvas.getContext('2d')
@@ -21,7 +22,7 @@ export const getImgFromSvg = (
           mermaidId,
         ) as HTMLImageElement
         if (!targetImg) {
-          throw new Error(`Element '${mermaidId}' not found`)
+          onError( new Error(`Element '${mermaidId}' not found`))
         }
 
         targetImg.src = url
@@ -29,13 +30,13 @@ export const getImgFromSvg = (
           URL.revokeObjectURL(url)
         }
       } else {
-        throw new Error('Unable to create blob')
+        onError( new Error('Unable to create blob'))
       }
     }, 'image/png')
   }
 
   img.onerror = () => {
-    throw new Error('Unable to load SVG')
+    onError("Image rendering failed")
   }
 
   img.src = 'data:image/svg+xml;base64,' + Base64.encode(svg)


### PR DESCRIPTION
Using a trick from the Mermaid CLI. Diagrams with embedded line breaks (`<br>`) cause rendering errors unless they're properly converted to XML (`<br/>`). This will affect any other HTML that gets accidentally embedded.

Using the XMLSerializer is a generic fix, a lot better than trying to create a list of elements to fix.

Fixes #23

ref mermaid-cli:

https://github.com/mermaid-js/mermaid-cli/blob/f235609053213226c733fa2d7caa87b2839991bb/src/index.js#L311-L312